### PR TITLE
Update link to GGTips

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@
 ## Interactive
 
 * {[ggiraph](https://davidgohel.github.io/ggiraph/)}: Make 'ggplot' Graphics Interactive
-* {[ggtips](https://github.com/Roche/ggtips)}: Adds interactive tooltip boxes to ggplots (standalone or rendered in Shiny)
+* {[ggtips](https://github.com/cosi1/ggtips)}: Adds interactive tooltip boxes to ggplots (standalone or rendered in Shiny)
 * {[plotly](https://github.com/ropensci/plotly)}: An interactive graphing library for R
 
 


### PR DESCRIPTION
The original project for unknown reasons got deleted by Roche. The link points into a fork, but this is the main author of the project that was able to recover the project. So if there will be any changes to the project, it will probably be there.
