### PR TITLE
add the gameofthrones palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@
 * {[duke](https://aidangildea.github.io/duke/)}: Creating a Color-Blind Friendly Duke Color Package
 * {[dutchmasters](https://github.com/EdwinTh/dutchmasters)}: R package with colour palettes derived from famous paintings by 17th century Dutch masers
 * {[tricolore](https://github.com/jschoeley/tricolore)}: A flexible color scale for ternary compositions
+* {[gameofthrones](https://github.com/aljrico/gameofthrones)}: Game of Thrones inspired palette for R
 * {[ggdc](https://github.com/datacamp/ggdc)}: Datacamp Themes for ggplot2
 * {[ggcharts](https://github.com/thomas-neitmann/ggcharts)}: Get You to Your Desired Plot Faster
 * {[ggcute](https://github.com/sharlagelfand/ggcute/)}: Cute things for ggplot2


### PR DESCRIPTION
I was exploring different palettes and came across this interesting repository: https://github.com/aljrico/gameofthrones.

I believe the palette could be especially appealing to those who enjoy the colors inspired by Game of Thrones. Therefore, I have included it in the list.

I hope my suggestion adds value to the repository.